### PR TITLE
Fixed ClassNotFoundException when parsing namespaces in (use)

### DIFF
--- a/src/repetition/hunter/core.clj
+++ b/src/repetition/hunter/core.clj
@@ -34,7 +34,7 @@
   [f ns]
   (->> (flatten f)
        (filter symbol?)
-       (remove #(or (ns-resolve ns %) (exclusion-words (name %)) (= \. (first (name %))) (= \. (last (name %)))))
+       (remove #(or (find-ns %) (ns-resolve ns %) (exclusion-words (name %)) (= \. (first (name %))) (= \. (last (name %)))))
        (into #{})))
 
 (defn- make-generic
@@ -186,3 +186,4 @@
          (filter-results (:filter options))
          (sort-results sort)
          print-results)))
+


### PR DESCRIPTION
When parsing a file with a quoted namespace, such as in use, require, or refer, repetition hunter simply prints "Hunt failed" followed by the quoted namespace. This is due to ns-resolve throwing a ClassNotFoundException when passed a symbol containing a dot. This is a fix for normal usage of functions that take in a namespace. A fix is still needed for the general case of using a symbol containing a dot.
