### PR TITLE
Fixed ClassNotFoundException when file contains namespace-like symbols

### DIFF
--- a/src/repetition/hunter/core.clj
+++ b/src/repetition/hunter/core.clj
@@ -34,7 +34,12 @@
   [f ns]
   (->> (flatten f)
        (filter symbol?)
-       (remove #(or (find-ns %) (ns-resolve ns %) (exclusion-words (name %)) (= \. (first (name %))) (= \. (last (name %)))))
+       (remove #(or
+                 (and (some (partial = \.) (name %)) (not-any? (partial = \/) (name %)))
+                 (ns-resolve ns %)
+                 (exclusion-words (name %))
+                 (= \. (first (name %)))
+                 (= \. (last (name %)))))
        (into #{})))
 
 (defn- make-generic


### PR DESCRIPTION
ns-resolve throws ClassNotFoundException when passed a namespace-like symbol. Ignored symbols containing a dot and no forward-slash.
